### PR TITLE
Add minimal, material, glass, neumorphism, and retro UI style variants

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -447,6 +447,18 @@
                             </div>
                         </div>
 
+                        <div class="flex flex-row w-full justify-between items-center">
+                            <p>Style: </p>
+                            <select class={"timer-select-" + settings.theme.buttonStyle + " timer-common-" + settings.theme.buttonStyle} bind:value={settings.theme.buttonStyle}>
+                                <option value="default">Default</option>
+                                <option value="minimal">Minimal</option>
+                                <option value="material">Material</option>
+                                <option value="glass">Glass</option>
+                                <option value="neumorphism">Soft UI</option>
+                                <option value="retro">Retro</option>
+                            </select>
+                        </div>
+
                         <div class="flex flex-row gap-1.5 justify-between w-full items-center">
                             <div>Font:</div>
                             <input oninput={()=>{updateColor('--font-family', settings.theme.fontFamily);}} class={"w-full timer-input-" + settings.theme.buttonStyle+ " timer-common-" + settings.theme.buttonStyle} type="text" bind:value={settings.theme.fontFamily}

--- a/src/lib/interfaces/Theme.ts
+++ b/src/lib/interfaces/Theme.ts
@@ -6,6 +6,6 @@ export default interface Theme {
     timerType: TimerType;
     //fontsize
     fontFamily: string;
-    buttonStyle: "default" | "minimal" | "custom";
+    buttonStyle: "default" | "minimal" | "material" | "glass" | "neumorphism" | "retro";
     iconPack: "default" | "colorful" | "minimal";
 }

--- a/src/lib/styles/Button.css
+++ b/src/lib/styles/Button.css
@@ -28,3 +28,156 @@
     cursor: default;
     color: var(--text-col);
 }
+
+/* --- Minimal --- */
+.timer-button-minimal {
+    outline: none;
+    border-radius: 4px;
+    color: var(--text-col);
+    font-size: 36px;
+    transition: all 150ms;
+    padding: 4px;
+    display: grid;
+    place-items: center;
+}
+.timer-button-minimal:not([disabled]):hover {
+    background: var(--secondary-col) !important;
+    cursor: pointer;
+}
+.timer-button-minimal:not([disabled]):focus {
+    outline: 2px solid var(--text-col);
+    outline-offset: 2px;
+}
+.timer-button-minimal:disabled {
+    cursor: default;
+    opacity: 0.5;
+}
+
+/* --- Material --- */
+.timer-button-material {
+    outline: none;
+    border-radius: 24px;
+    color: var(--text-col);
+    font-size: 36px;
+    transition: all 200ms cubic-bezier(0.2, 0, 0, 1);
+    padding: 4px;
+    display: grid;
+    place-items: center;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.3), 0 1px 2px rgba(0,0,0,0.2);
+}
+.timer-button-material:not([disabled]):hover {
+    background: var(--secondary-col) !important;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.35), 0 2px 4px rgba(0,0,0,0.2);
+    cursor: pointer;
+    transform: scale(1.05);
+}
+.timer-button-material:not([disabled]):focus {
+    outline: none;
+    box-shadow: 0 0 0 3px var(--timer-background-col);
+}
+.timer-button-material:not([disabled]):active {
+    background: var(--secondary-col) !important;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+    transform: scale(0.98);
+}
+.timer-button-material:disabled {
+    cursor: default;
+    opacity: 0.5;
+}
+
+/* --- Glass --- */
+.timer-button-glass {
+    outline: none;
+    border-radius: 12px;
+    color: var(--text-col);
+    font-size: 36px;
+    transition: all 200ms;
+    padding: 4px;
+    display: grid;
+    place-items: center;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    box-shadow: 0 4px 16px rgba(0,0,0,0.25);
+}
+.timer-button-glass:not([disabled]):hover {
+    background: rgba(255,255,255,0.16) !important;
+    border-color: rgba(255,255,255,0.35) !important;
+    box-shadow: 0 6px 20px rgba(0,0,0,0.35);
+    cursor: pointer;
+    transform: scale(1.05);
+}
+.timer-button-glass:not([disabled]):focus {
+    outline: none;
+    border-color: rgba(255,255,255,0.5) !important;
+    box-shadow: 0 0 0 2px rgba(255,255,255,0.25), 0 4px 16px rgba(0,0,0,0.25);
+}
+.timer-button-glass:not([disabled]):active {
+    background: rgba(255,255,255,0.14) !important;
+    transform: scale(1.02);
+}
+.timer-button-glass:disabled {
+    cursor: default;
+    opacity: 0.5;
+}
+
+/* --- Neumorphism --- */
+.timer-button-neumorphism {
+    outline: none;
+    border-radius: 12px;
+    color: var(--text-col);
+    font-size: 36px;
+    transition: all 200ms;
+    padding: 4px;
+    display: grid;
+    place-items: center;
+    box-shadow: 5px 5px 10px rgba(0,0,0,0.35), -3px -3px 8px rgba(255,255,255,0.06);
+}
+.timer-button-neumorphism:not([disabled]):hover {
+    background: var(--secondary-col) !important;
+    box-shadow: 7px 7px 14px rgba(0,0,0,0.4), -4px -4px 10px rgba(255,255,255,0.08);
+    cursor: pointer;
+}
+.timer-button-neumorphism:not([disabled]):focus {
+    outline: none;
+    box-shadow: 5px 5px 10px rgba(0,0,0,0.35), -3px -3px 8px rgba(255,255,255,0.06), 0 0 0 2px var(--secondary-col);
+}
+.timer-button-neumorphism:not([disabled]):active {
+    box-shadow: inset 3px 3px 6px rgba(0,0,0,0.35), inset -2px -2px 5px rgba(255,255,255,0.05);
+}
+.timer-button-neumorphism:disabled {
+    cursor: default;
+    opacity: 0.5;
+}
+
+/* --- Retro --- */
+.timer-button-retro {
+    outline: none;
+    border-radius: 0;
+    color: var(--text-col);
+    font-size: 36px;
+    transition: all 150ms;
+    padding: 4px;
+    display: grid;
+    place-items: center;
+    text-shadow: 0 0 8px var(--text-col);
+    box-shadow: 0 0 4px var(--text-col);
+}
+.timer-button-retro:not([disabled]):hover {
+    background: var(--text-col) !important;
+    border-color: var(--text-col) !important;
+    color: var(--background-col);
+    text-shadow: none;
+    box-shadow: 0 0 12px var(--text-col);
+    cursor: pointer;
+}
+.timer-button-retro:not([disabled]):focus {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--text-col), 0 0 8px var(--text-col);
+}
+.timer-button-retro:not([disabled]):active {
+    background: var(--secondary-col) !important;
+}
+.timer-button-retro:disabled {
+    cursor: default;
+    opacity: 0.5;
+}

--- a/src/lib/styles/CheckBoxInput.css
+++ b/src/lib/styles/CheckBoxInput.css
@@ -71,3 +71,139 @@
     cursor: default;
     opacity: 0.6;
 }
+
+/* --- Shared checkbox base (all non-default variants inherit these) --- */
+.timer-checkbox-minimal,
+.timer-checkbox-material,
+.timer-checkbox-glass,
+.timer-checkbox-neumorphism,
+.timer-checkbox-retro {
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    outline: none;
+    width: 25px;
+    height: 25px;
+    vertical-align: middle;
+    position: relative;
+    cursor: pointer;
+    transition: all 150ms ease-out;
+}
+
+.timer-checkbox-minimal::after,
+.timer-checkbox-material::after,
+.timer-checkbox-glass::after,
+.timer-checkbox-neumorphism::after,
+.timer-checkbox-retro::after {
+    content: '';
+    position: absolute;
+    display: none;
+    left: 8px;
+    top: 3px;
+    width: 6px;
+    height: 12px;
+    border: solid var(--text-col);
+    border-width: 0 3px 3px 0;
+    transform: rotate(45deg);
+}
+
+.timer-checkbox-minimal:checked::after,
+.timer-checkbox-material:checked::after,
+.timer-checkbox-glass:checked::after,
+.timer-checkbox-neumorphism:checked::after,
+.timer-checkbox-retro:checked::after {
+    display: block;
+}
+
+/* --- Minimal --- */
+.timer-checkbox-minimal {
+    border-radius: 2px;
+}
+.timer-checkbox-minimal:checked {
+    background: var(--secondary-col) !important;
+}
+.timer-checkbox-minimal:not([disabled]):hover {
+    background: var(--secondary-col) !important;
+}
+.timer-checkbox-minimal:not([disabled]):focus {
+    outline: 2px solid var(--text-col);
+    outline-offset: 2px;
+}
+.timer-checkbox-minimal:disabled { cursor: default; opacity: 0.5; }
+
+/* --- Material --- */
+.timer-checkbox-material {
+    border-radius: 6px;
+}
+.timer-checkbox-material:checked {
+    background: var(--secondary-col) !important;
+}
+.timer-checkbox-material:not([disabled]):hover {
+    background: var(--secondary-col) !important;
+}
+.timer-checkbox-material:not([disabled]):focus {
+    outline: none;
+    box-shadow: 0 0 0 3px var(--timer-background-col);
+}
+.timer-checkbox-material:disabled { cursor: default; opacity: 0.5; }
+
+/* --- Glass --- */
+.timer-checkbox-glass {
+    border-radius: 6px;
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+}
+.timer-checkbox-glass:checked {
+    background: rgba(255,255,255,0.25) !important;
+    border-color: rgba(255,255,255,0.5) !important;
+}
+.timer-checkbox-glass:not([disabled]):hover {
+    background: rgba(255,255,255,0.18) !important;
+    border-color: rgba(255,255,255,0.4) !important;
+}
+.timer-checkbox-glass:not([disabled]):focus {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(255,255,255,0.3);
+}
+.timer-checkbox-glass:disabled { cursor: default; opacity: 0.5; }
+
+/* --- Neumorphism --- */
+.timer-checkbox-neumorphism {
+    border-radius: 6px;
+    box-shadow: 3px 3px 6px rgba(0,0,0,0.3), -2px -2px 5px rgba(255,255,255,0.06);
+}
+.timer-checkbox-neumorphism:checked {
+    background: var(--secondary-col) !important;
+    box-shadow: inset 2px 2px 4px rgba(0,0,0,0.3), inset -1px -1px 3px rgba(255,255,255,0.05);
+}
+.timer-checkbox-neumorphism:not([disabled]):hover {
+    background: var(--secondary-col) !important;
+}
+.timer-checkbox-neumorphism:not([disabled]):focus {
+    outline: none;
+    box-shadow: 3px 3px 6px rgba(0,0,0,0.3), -2px -2px 5px rgba(255,255,255,0.06), 0 0 0 2px var(--secondary-col);
+}
+.timer-checkbox-neumorphism:disabled { cursor: default; opacity: 0.5; }
+
+/* --- Retro --- */
+.timer-checkbox-retro {
+    border-radius: 0;
+    box-shadow: 0 0 4px var(--text-col);
+}
+.timer-checkbox-retro::after {
+    border-color: var(--background-col);
+}
+.timer-checkbox-retro:checked {
+    background: var(--text-col) !important;
+    border-color: var(--text-col) !important;
+    box-shadow: 0 0 8px var(--text-col);
+}
+.timer-checkbox-retro:not([disabled]):hover {
+    background: var(--secondary-col) !important;
+    box-shadow: 0 0 8px var(--text-col);
+}
+.timer-checkbox-retro:not([disabled]):focus {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--text-col), 0 0 8px var(--text-col);
+}
+.timer-checkbox-retro:disabled { cursor: default; opacity: 0.5; }

--- a/src/lib/styles/ColorInput.css
+++ b/src/lib/styles/ColorInput.css
@@ -47,3 +47,49 @@
     border: 5px solid var(--secondary-col);
     border-radius: 3px;
 }
+
+/* --- Shared base for all non-default variants --- */
+.timer-color-input-minimal,
+.timer-color-input-material,
+.timer-color-input-glass,
+.timer-color-input-neumorphism,
+.timer-color-input-retro {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    background-color: transparent;
+    width: 40px;
+    height: 40px;
+    border: none;
+    padding: 0;
+    margin: 0 4px;
+    cursor: pointer;
+}
+
+.timer-color-input-minimal::-webkit-color-swatch-wrapper,
+.timer-color-input-material::-webkit-color-swatch-wrapper,
+.timer-color-input-glass::-webkit-color-swatch-wrapper,
+.timer-color-input-neumorphism::-webkit-color-swatch-wrapper,
+.timer-color-input-retro::-webkit-color-swatch-wrapper {
+    padding: 0;
+}
+
+/* Minimal */
+.timer-color-input-minimal::-webkit-color-swatch { border: 2px solid var(--secondary-col); border-radius: 2px; }
+.timer-color-input-minimal::-moz-color-swatch    { border: 2px solid var(--secondary-col); border-radius: 2px; }
+
+/* Material */
+.timer-color-input-material::-webkit-color-swatch { border: 3px solid var(--secondary-col); border-radius: 12px; }
+.timer-color-input-material::-moz-color-swatch    { border: 3px solid var(--secondary-col); border-radius: 12px; }
+
+/* Glass */
+.timer-color-input-glass::-webkit-color-swatch { border: 2px solid rgba(255,255,255,0.35); border-radius: 6px; }
+.timer-color-input-glass::-moz-color-swatch    { border: 2px solid rgba(255,255,255,0.35); border-radius: 6px; }
+
+/* Neumorphism */
+.timer-color-input-neumorphism::-webkit-color-swatch { border: none; border-radius: 8px; box-shadow: 3px 3px 6px rgba(0,0,0,0.3), -2px -2px 5px rgba(255,255,255,0.06); }
+.timer-color-input-neumorphism::-moz-color-swatch    { border: none; border-radius: 8px; }
+
+/* Retro */
+.timer-color-input-retro::-webkit-color-swatch { border: 2px solid var(--text-col); border-radius: 0; box-shadow: 0 0 4px var(--text-col); }
+.timer-color-input-retro::-moz-color-swatch    { border: 2px solid var(--text-col); border-radius: 0; }

--- a/src/lib/styles/Input.css
+++ b/src/lib/styles/Input.css
@@ -1,3 +1,28 @@
 .timer-input-default{
     border-radius: 10px;
 }
+
+.timer-input-minimal{
+    border-radius: 4px;
+}
+
+.timer-input-material{
+    border-radius: 12px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+}
+
+.timer-input-glass{
+    border-radius: 8px;
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+}
+
+.timer-input-neumorphism{
+    border-radius: 8px;
+    box-shadow: inset 2px 2px 5px rgba(0,0,0,0.25), inset -1px -1px 4px rgba(255,255,255,0.05);
+}
+
+.timer-input-retro{
+    border-radius: 0;
+    font-family: 'Courier New', Courier, monospace;
+}

--- a/src/lib/styles/Select.css
+++ b/src/lib/styles/Select.css
@@ -4,3 +4,43 @@
     border-radius: 10px;
     width: 120px;
 }
+
+.timer-select-minimal{
+    font-size: 18px;
+    padding: 5px;
+    border-radius: 4px;
+    width: 120px;
+}
+
+.timer-select-material{
+    font-size: 18px;
+    padding: 5px;
+    border-radius: 12px;
+    width: 120px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+}
+
+.timer-select-glass{
+    font-size: 18px;
+    padding: 5px;
+    border-radius: 8px;
+    width: 120px;
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+}
+
+.timer-select-neumorphism{
+    font-size: 18px;
+    padding: 5px;
+    border-radius: 8px;
+    width: 120px;
+    box-shadow: inset 2px 2px 5px rgba(0,0,0,0.25), inset -1px -1px 4px rgba(255,255,255,0.05);
+}
+
+.timer-select-retro{
+    font-size: 18px;
+    padding: 5px;
+    border-radius: 0;
+    width: 120px;
+    font-family: 'Courier New', Courier, monospace;
+}

--- a/src/lib/styles/UICommon.css
+++ b/src/lib/styles/UICommon.css
@@ -7,3 +7,23 @@
     background: transparent;
     border: none;
 }
+
+.timer-common-material{
+    background: var(--primary-col);
+    border: none;
+}
+
+.timer-common-glass{
+    background: rgba(255,255,255,0.08);
+    border: 1px solid rgba(255,255,255,0.18);
+}
+
+.timer-common-neumorphism{
+    background: var(--primary-col);
+    border: none;
+}
+
+.timer-common-retro{
+    background: transparent;
+    border: 1px solid var(--text-col);
+}


### PR DESCRIPTION
Extends the existing timer-button-{style}/timer-common-{style} pattern with five new variants across all component CSS files (Button, CheckBoxInput, ColorInput, Input, Select, UICommon). Expands the buttonStyle union type in Theme.ts and adds a Style picker dropdown to the settings panel in App.svelte.